### PR TITLE
클라이언트, 서버 핸들러 매핑 uri 수정

### DIFF
--- a/src/main/kotlin/hntech/hntechserver/common/GlobalController.kt
+++ b/src/main/kotlin/hntech/hntechserver/common/GlobalController.kt
@@ -3,10 +3,12 @@ package hntech.hntechserver.common
 import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Controller
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import javax.servlet.http.HttpServletRequest
 
 @RestController
+@RequestMapping("/api")
 class GlobalController() {
 
 //    @GetMapping("/")
@@ -25,22 +27,13 @@ class GlobalController() {
 class ReactClientRedirector {
     @GetMapping(value = [
         "",
+        "/",
         "/company",
-        "/client-product",
-        "/product-detail",
-        "/product-form",
-        "/product-modify",
-        "/productCategory-form",
-        "/productCategory-modify",
+        "/product/**",
+        "/productCategory/**",
         "/document",
-        "/client-question",
-        "/question-form",
-        "/question-modify",
-        "/question-detail",
-        "/client-archive",
-        "/archive-form",
-        "/archive-detail",
-        "/archive-modify"
+        "/question/**",
+        "/archive/**"
     ])
     fun redirect() = "forward:/index.html"
 }

--- a/src/main/kotlin/hntech/hntechserver/domain/admin/AdminController.kt
+++ b/src/main/kotlin/hntech/hntechserver/domain/admin/AdminController.kt
@@ -9,7 +9,7 @@ import javax.servlet.http.HttpServletResponse
 import javax.validation.Valid
 
 @RestController
-@RequestMapping("/admin")
+@RequestMapping("/api/admin")
 class AdminController(private val adminService: AdminService) {
     /**
      * 사용자 모드

--- a/src/main/kotlin/hntech/hntechserver/domain/archive/ArchiveController.kt
+++ b/src/main/kotlin/hntech/hntechserver/domain/archive/ArchiveController.kt
@@ -11,7 +11,7 @@ import javax.validation.Valid
 
 
 @RestController
-@RequestMapping("/archive")
+@RequestMapping("/api/archive")
 class ArchiveController(private val archiveService: ArchiveService) {
     /**
      * 사용자 모드

--- a/src/main/kotlin/hntech/hntechserver/domain/category/CategoryController.kt
+++ b/src/main/kotlin/hntech/hntechserver/domain/category/CategoryController.kt
@@ -6,7 +6,7 @@ import org.springframework.web.bind.annotation.*
 import javax.validation.Valid
 
 @RestController
-@RequestMapping("/category")
+@RequestMapping("/api/category")
 class CategoryController(private val categoryService: CategoryService) {
     /**
      * 사용자 모드

--- a/src/main/kotlin/hntech/hntechserver/domain/file/FileController.kt
+++ b/src/main/kotlin/hntech/hntechserver/domain/file/FileController.kt
@@ -17,7 +17,7 @@ import java.nio.charset.Charset
 
 
 @RestController
-@RequestMapping("/file")
+@RequestMapping("/api/file")
 class FileController(private val fileService: FileService) {
 
     @ApiOperation(

--- a/src/main/kotlin/hntech/hntechserver/domain/product/ProductController.kt
+++ b/src/main/kotlin/hntech/hntechserver/domain/product/ProductController.kt
@@ -7,7 +7,7 @@ import org.springframework.web.bind.annotation.*
 import javax.validation.Valid
 
 @RestController
-@RequestMapping("/product")
+@RequestMapping("/api/product")
 class ProductController(private val productService: ProductService) {
     /**
      * 사용자 모드

--- a/src/main/kotlin/hntech/hntechserver/domain/question/controller/AdminQuestionController.kt
+++ b/src/main/kotlin/hntech/hntechserver/domain/question/controller/AdminQuestionController.kt
@@ -9,7 +9,7 @@ import org.springframework.web.bind.annotation.*
 import javax.validation.Valid
 
 @RestController
-@RequestMapping("/admin/question")
+@RequestMapping("/api/admin/question")
 class AdminQuestionController(private val questionService: QuestionService) {
 
     /**

--- a/src/main/kotlin/hntech/hntechserver/domain/question/controller/ClientQuestionController.kt
+++ b/src/main/kotlin/hntech/hntechserver/domain/question/controller/ClientQuestionController.kt
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.*
 import javax.validation.Valid
 
 @RestController
-@RequestMapping("/question")
+@RequestMapping("/api/question")
 class ClientQuestionController(private val questionService: QuestionService) {
 
     /**

--- a/src/main/kotlin/hntech/hntechserver/domain/question/controller/CommentController.kt
+++ b/src/main/kotlin/hntech/hntechserver/domain/question/controller/CommentController.kt
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.*
 import javax.validation.Valid
 
 @RestController
-@RequestMapping("/question/{questionId}/comment")
+@RequestMapping("/api/question/{questionId}/comment")
 class CommentController(private val questionService: QuestionService) {
 
     @PostMapping


### PR DESCRIPTION
서버측 모든 핸들러 매핑의 루트 경로에 /api 추가 (정적 페이지 제공 uri 매핑을 용이하게 하기 위함)